### PR TITLE
テキストエディットをテーブルビューに置き換え（Issue #4）

### DIFF
--- a/internal/filemodel/filemodel.go
+++ b/internal/filemodel/filemodel.go
@@ -1,0 +1,63 @@
+package filemodel
+
+import (
+	"time"
+
+	"github.com/lxn/walk"
+)
+
+// FileItem はZIPファイル内のファイルアイテムを表します
+type FileItem struct {
+	Name string
+	Size int64
+	Date time.Time
+}
+
+// FileItemModel はTableView用のモデルを表します
+type FileItemModel struct {
+	walk.TableModelBase
+	Items []FileItem
+}
+
+// RowCount は行数を返します
+func (m *FileItemModel) RowCount() int {
+	return len(m.Items)
+}
+
+// Value は指定された行と列の値を返します
+func (m *FileItemModel) Value(row, col int) interface{} {
+	if row < 0 || row >= len(m.Items) {
+		return nil
+	}
+
+	item := m.Items[row]
+
+	switch col {
+	case 0:
+		return item.Name
+	case 1:
+		return item.Size
+	case 2:
+		return item.Date.Format("2006/01/02 15:04:05")
+	}
+
+	return nil
+}
+
+// ColumnCount はカラム数を返します
+func (m *FileItemModel) ColumnCount() int {
+	return 3
+}
+
+// ColumnName は指定された列の名前を返します
+func (m *FileItemModel) ColumnName(col int) string {
+	switch col {
+	case 0:
+		return "ファイル名"
+	case 1:
+		return "サイズ"
+	case 2:
+		return "日付"
+	}
+	return ""
+}

--- a/internal/gui/window.go
+++ b/internal/gui/window.go
@@ -15,7 +15,7 @@ import (
 func CreateMainWindow() {
 	// メインウィンドウを作成
 	mw := new(walk.MainWindow)
-	var te *walk.TextEdit
+	var tableView *walk.TableView
 	var tv *walk.TreeView
 
 	// 現在のZIPファイルパスとモデル
@@ -40,13 +40,16 @@ func CreateMainWindow() {
 						StretchFactor:      5, // 左右の比率
 						AlwaysConsumeSpace: true,
 					},
-					// 右側：テキストエディット（ファイル一覧表示用）
-					TextEdit{
-						AssignTo:           &te,
+					// 右側：TableView（ファイル一覧表示用）
+					TableView{
+						AssignTo:           &tableView,
 						StretchFactor:      5, // 左右の比率
 						AlwaysConsumeSpace: true,
-						ReadOnly:           true,
-						VScroll:            true,
+						Columns: []TableViewColumn{
+							{Title: "ファイル名"},
+							{Title: "サイズ"},
+							{Title: "日付"},
+						},
 					},
 				},
 			},
@@ -102,7 +105,7 @@ func CreateMainWindow() {
 		item := tv.CurrentItem()
 		if zipItem, ok := item.(*model.ZipTreeItem); ok {
 			// 選択されたディレクトリ内のファイル一覧を表示
-			err := fileops.UpdateFileList(te, currentZipPath, zipItem.GetPath())
+			err := fileops.UpdateFileList(tableView, currentZipPath, zipItem.GetPath())
 			if err != nil {
 				walk.MsgBox(mw, "エラー", "ファイル一覧の更新に失敗しました: "+err.Error(), walk.MsgBoxIconError)
 			}

--- a/internal/model/zipmodel.go
+++ b/internal/model/zipmodel.go
@@ -113,6 +113,7 @@ func (m *ZipTreeModel) RootAt(index int) walk.TreeItem {
 	return m.rootItem
 }
 
+
 // LoadZipFile はZIPファイルを読み込み、ツリーモデルを作成します
 func LoadZipFile(filePath string) (*ZipTreeModel, error) {
 	reader, err := zip.OpenReader(filePath)


### PR DESCRIPTION
Issue #4 の実装：テキストエディットをテーブルビューに置き換えました。これにより、ファイル一覧がより見やすくなり、ファイルのサイズや日付も表示できるようになりました。

Close #4 